### PR TITLE
Added Queue<T> data scructure along with tests and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ The Swift standard library comes with a handful of data structures, including ar
 
 - Singly-linked list (have)
 - Doubly-linked list (need)
-- Heap (need)
+- Queue (have)
 - Stack (need)
-- Queue (need)
+- Heap (need)
 - Graph (need)
 - Binary search tree (need)
 

--- a/Source/Queue.swift
+++ b/Source/Queue.swift
@@ -35,7 +35,7 @@ public class Queue<T> {
         guard let currentList = list else {
             return nil
         }
-        list = list?.newListByIncrementingHead()
+        list = list?.newListByIncrementingRoot()
         count -= 1
         return currentList.rootNode.value
     }

--- a/Source/Queue.swift
+++ b/Source/Queue.swift
@@ -1,0 +1,62 @@
+//  Queue.swift
+//  SwiftStructures
+//  Created by Jake Hawken on 1/24/20.
+//  Copyright © 2020 Jake Hawken. All rights reserved.
+
+import Foundation
+
+public class Queue<T> {
+    
+    private var list: SinglyLinkedList<T>?
+    private(set) var count = 0
+    
+    var isEmpty: Bool {
+        return list == nil
+    }
+    
+    /**
+    Adds a new element to the queue.
+    - Parameter element: The value to be enqueued.
+    */
+    func enqueue(_ element: T) {
+        count += 1
+        guard let list = list else {
+            self.list = SinglyLinkedList(firstValue: element)
+            return
+        }
+        list.insert(value: element)
+    }
+    
+    /**
+    Pops the next element off of the front of the queue. Returns `nil` if the queue is empty. When an element is returned, it is removed from the queue.
+    - returns: The first element in the queue, based on a first-in-first-out rule.
+    */
+    func dequeue() -> T? {
+        guard let currentList = list else {
+            return nil
+        }
+        list = list?.newListByIncrementingHead()
+        count -= 1
+        return currentList.rootNode.value
+    }
+    
+    /**
+    Returns the next element in the queue without dequeueing it.
+    - returns: The element at the front of the queue.
+    */
+    var peek: T? {
+        return list?.rootNode.value
+    }
+    
+    /**
+    Dequeues all elements from the queue in order and returns them as an array. As this is iterative, this method is exectuted in O(n) time.
+    - returns: An array of the elements, in dequeueing order.
+    */
+    func dequeueAll() -> [T] {
+        let output = list?.asArray() ?? []
+        list = nil
+        count = 0
+        return output
+    }
+    
+}

--- a/Source/SinglyLinkedList.swift
+++ b/Source/SinglyLinkedList.swift
@@ -99,6 +99,23 @@ public class SinglyLinkedList<T> {
         self.rootNode = rootNode
         self.tailNode = rootNode.findTerminalNode()
     }
+    
+    /**
+    Returns a new linked list, but with the rootNode being the node after the current list's root node. If there is no second node, this method will return nil. Since the tail node is copied to the new list (rather than being found iteratively), this method finishes in constant time.
+    - returns: An optional SinglyLinkedList. Returns nil if `rootNode` has a nil `next` property.
+    */
+    func newListByIncrementingHead() -> SinglyLinkedList? {
+        guard let next = rootNode.next else {
+            return nil
+        }
+        return SinglyLinkedList(rootNode: next,
+                                tailNode: tailNode)
+    }
+    
+    private init(rootNode: SinglyLinkedListNode<T>, tailNode: SinglyLinkedListNode<T>) {
+        self.rootNode = rootNode
+        self.tailNode = tailNode
+    }
 }
 
 public extension SinglyLinkedList {
@@ -144,7 +161,7 @@ public extension SinglyLinkedList {
 
 public extension SinglyLinkedList {
     /**
-    Inserts a value onto the end of the list. Since references are maintained to the r`oot and tail of the list, insertion happens in O(1) time.
+    Inserts a value onto the end of the list. Since references are maintained to the root and tail of the list, insertion happens in constant time.
     - Parameter value: The value that will go into the new tailNode of the list.
     */
     func insert(value: T) {
@@ -172,6 +189,7 @@ public extension SinglyLinkedList {
     
     /**
     Generates an array from the contents of the list, honoring the data order. e.g. List{ (0)->(1)->(2) } will generate [0,1,2]
+    - returns: An array corresponding to the values of the list's nodes. Guaranteed to have at leats one element.
     */
     func asArray() -> [T] {
         var output = [T]()

--- a/Source/SinglyLinkedList.swift
+++ b/Source/SinglyLinkedList.swift
@@ -104,7 +104,7 @@ public class SinglyLinkedList<T> {
     Returns a new linked list, but with the rootNode being the node after the current list's root node. If there is no second node, this method will return nil. Since the tail node is copied to the new list (rather than being found iteratively), this method finishes in constant time.
     - returns: An optional SinglyLinkedList. Returns nil if `rootNode` has a nil `next` property.
     */
-    func newListByIncrementingHead() -> SinglyLinkedList? {
+    func newListByIncrementingRoot() -> SinglyLinkedList? {
         guard let next = rootNode.next else {
             return nil
         }

--- a/SwiftStructures.xcodeproj/project.pbxproj
+++ b/SwiftStructures.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		0928BB4023D7EF070098FB9B /* SinglyLinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0928BB3F23D7EF070098FB9B /* SinglyLinkedList.swift */; };
 		0928BB4223D8ACE10098FB9B /* SinglyLinkedListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0928BB4123D8ACE10098FB9B /* SinglyLinkedListTests.swift */; };
 		0928BB4C23DC03400098FB9B /* InternalUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0928BB4B23DC03400098FB9B /* InternalUtilities.swift */; };
+		0928BB4E23DC0E1A0098FB9B /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0928BB4D23DC0E1A0098FB9B /* Queue.swift */; };
+		0928BB5023DC130D0098FB9B /* QueueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0928BB4F23DC130D0098FB9B /* QueueTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -42,6 +44,8 @@
 		0928BB3F23D7EF070098FB9B /* SinglyLinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglyLinkedList.swift; sourceTree = "<group>"; };
 		0928BB4123D8ACE10098FB9B /* SinglyLinkedListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SinglyLinkedListTests.swift; sourceTree = "<group>"; };
 		0928BB4B23DC03400098FB9B /* InternalUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternalUtilities.swift; sourceTree = "<group>"; };
+		0928BB4D23DC0E1A0098FB9B /* Queue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queue.swift; sourceTree = "<group>"; };
+		0928BB4F23DC130D0098FB9B /* QueueTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueueTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +103,7 @@
 			isa = PBXGroup;
 			children = (
 				0928BB4123D8ACE10098FB9B /* SinglyLinkedListTests.swift */,
+				0928BB4F23DC130D0098FB9B /* QueueTests.swift */,
 				0928BB3523D7EEB40098FB9B /* Info.plist */,
 			);
 			path = SwiftStructuresTests;
@@ -108,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				0928BB3F23D7EF070098FB9B /* SinglyLinkedList.swift */,
+				0928BB4D23DC0E1A0098FB9B /* Queue.swift */,
 				0928BB4B23DC03400098FB9B /* InternalUtilities.swift */,
 			);
 			path = Source;
@@ -218,6 +224,7 @@
 				0928BB1D23D7EEB20098FB9B /* AppDelegate.swift in Sources */,
 				0928BB4023D7EF070098FB9B /* SinglyLinkedList.swift in Sources */,
 				0928BB4C23DC03400098FB9B /* InternalUtilities.swift in Sources */,
+				0928BB4E23DC0E1A0098FB9B /* Queue.swift in Sources */,
 				0928BB1F23D7EEB20098FB9B /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -227,6 +234,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0928BB4223D8ACE10098FB9B /* SinglyLinkedListTests.swift in Sources */,
+				0928BB5023DC130D0098FB9B /* QueueTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftStructuresTests/QueueTests.swift
+++ b/SwiftStructuresTests/QueueTests.swift
@@ -1,0 +1,92 @@
+//  QueueTests.swift
+//  SwiftStructuresTests
+//  Created by Jake Hawken on 1/24/20.
+//  Copyright © 2020 Jake Hawken. All rights reserved.
+
+import XCTest
+@testable import SwiftStructures
+
+class QueueTests: XCTestCase {
+
+    override func setUp() {}
+
+    override func tearDown() {}
+
+    func testEnqueueAndDequeue() {
+        let subject = Queue<Int>()
+        XCTAssert(subject.dequeue() == nil)
+        XCTAssert(subject.isEmpty)
+        subject.enqueue(1)
+        XCTAssertFalse(subject.isEmpty)
+        subject.enqueue(2)
+        XCTAssertFalse(subject.isEmpty)
+        subject.enqueue(3)
+        XCTAssertFalse(subject.isEmpty)
+        subject.enqueue(4)
+        XCTAssertFalse(subject.isEmpty)
+        subject.enqueue(5)
+        XCTAssertFalse(subject.isEmpty)
+        XCTAssert(subject.dequeue() == 1)
+        XCTAssertFalse(subject.isEmpty)
+        XCTAssert(subject.dequeue() == 2)
+        XCTAssertFalse(subject.isEmpty)
+        XCTAssert(subject.dequeue() == 3)
+        XCTAssertFalse(subject.isEmpty)
+        XCTAssert(subject.dequeue() == 4)
+        XCTAssertFalse(subject.isEmpty)
+        XCTAssert(subject.dequeue() == 5)
+        XCTAssert(subject.isEmpty)
+        XCTAssert(subject.dequeue() == nil)
+        XCTAssert(subject.isEmpty)
+    }
+    
+    func testCount() {
+        let subject = Queue<Int>()
+        XCTAssert(subject.count == 0)
+        subject.enqueue(1)
+        XCTAssert(subject.count == 1)
+        subject.enqueue(2)
+        XCTAssert(subject.count == 2)
+        subject.enqueue(3)
+        XCTAssert(subject.count == 3)
+        subject.enqueue(4)
+        XCTAssert(subject.count == 4)
+        subject.enqueue(5)
+        XCTAssert(subject.count == 5)
+        _ = subject.dequeue()
+        XCTAssert(subject.count == 4)
+        _ = subject.dequeue()
+        XCTAssert(subject.count == 3)
+        _ = subject.dequeue()
+        XCTAssert(subject.count == 2)
+        _ = subject.dequeue()
+        XCTAssert(subject.count == 1)
+        _ = subject.dequeue()
+        XCTAssert(subject.count == 0)
+        XCTAssert(subject.isEmpty)
+        subject.enqueue(1)
+        XCTAssert(subject.count == 1)
+    }
+    
+    func testPeek() {
+        let subject = Queue<Int>()
+        subject.enqueue(1)
+        subject.enqueue(3)
+        subject.enqueue(3)
+        XCTAssert(subject.count == 3)
+        XCTAssert(subject.peek == 1)
+        XCTAssert(subject.count == 3)
+    }
+    
+    func testPopAll() {
+        let subject = Queue<Int>()
+        subject.enqueue(1)
+        subject.enqueue(2)
+        subject.enqueue(3)
+        XCTAssert(subject.count == 3)
+        XCTAssert(subject.dequeueAll() == [1,2,3])
+        XCTAssert(subject.count == 0)
+        XCTAssert(subject.isEmpty)
+    }
+
+}


### PR DESCRIPTION
Also:
- Added method to SinglyLinkedList called `newListByIncrementingRoot()` which generates an optional list, in constant time, where the root is the next node down from the previous root. If the rootNode's `next` property is nil, this method returns nil. This allows `Queue<T>`, which is backed by an optional `SinglyLinkedList<T>` to enqueue and dequeue in constant time. The only O(n) operation on it is the `dequeueAll()` method.